### PR TITLE
cshared: plugin: Tweak for workflow of registerWG

### DIFF
--- a/cshared.go
+++ b/cshared.go
@@ -47,9 +47,7 @@ var (
 //
 //export FLBPluginPreRegister
 func FLBPluginPreRegister(hotReloading C.int) int {
-	if hotReloading == C.int(1) {
-		registerWG.Add(1)
-	}
+	registerWG.Add(1)
 
 	return input.FLB_OK
 }

--- a/plugin.go
+++ b/plugin.go
@@ -30,7 +30,6 @@ var (
 )
 
 func init() {
-	registerWG.Add(1)
 	theChannel = nil
 }
 


### PR DESCRIPTION
During to confirm the behavior of Golang plugin loading for https://github.com/fluent/fluent-bit/issues/9729,
I found that Golang plugins are not loaded due to glitches of waitgroup add/done sequence.

Now, we have FLBPreRegister callback which is ensured to be executed before entering FLBPluginRegister.
With using this callback, we can ensure the add/done sequence of registerWG wait group.

