### PR TITLE
cshared: Make longer liveness of custom plugin

### DIFF
--- a/cshared.go
+++ b/cshared.go
@@ -133,10 +133,10 @@ func FLBPluginInit(ptr unsafe.Pointer) int {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	var err error
 	if theInput != nil {
+		defer cancel()
 		conf := &flbInputConfigLoader{ptr: ptr}
 		cmt, err = input.FLBPluginGetCMetricsContext(ptr)
 		if err != nil {
@@ -157,6 +157,7 @@ func FLBPluginInit(ptr unsafe.Pointer) int {
 			}
 		}
 	} else if theOutput != nil {
+		defer cancel()
 		conf := &flbOutputConfigLoader{ptr: ptr}
 		cmt, err = output.FLBPluginGetCMetricsContext(ptr)
 		if err != nil {
@@ -170,6 +171,8 @@ func FLBPluginInit(ptr unsafe.Pointer) int {
 		}
 		err = theOutput.Init(ctx, fbit)
 	} else {
+		// intended to longer liveness for custom plugin
+		runCancel = cancel
 		conf := &flbCustomConfigLoader{ptr: ptr}
 		logger = &flbCustomLogger{ptr: ptr}
 		fbit := &Fluentbit{


### PR DESCRIPTION
This is because this context cancellation causes immediate cancelling for Init function of ctx.Done().
To clean processing of custom plugin should be handled by ctx.Done(). We can introduce another way of monitoring the liveness of custom plugin of Init function of gouroutines.
But it tends to introduce bugs. So, we should change the behavior of context cancel for custom plugin.