### PR TITLE
fix: plugin_test failing.

### DIFF
--- a/plugin_test.go
+++ b/plugin_test.go
@@ -41,7 +41,8 @@ func testPlugin(t *testing.T, pool *dockertest.Pool) {
 	}()
 
 	// Set permissions on the file to be writable
-	err = os.Chmod(f.Name(), 0o600)
+	//nolint:gosec //must allow container to read output.txt
+	err = os.Chmod(f.Name(), 0o777)
 	assert.NoError(t, err)
 
 	buildOpts := dc.BuildImageOptions{


### PR DESCRIPTION
golangci-lint complained about open permissions but we need to expose the file to test the plugin in the container. nolinting it for now.