### PR TITLE
bug: Preserve types when decoding records [sc-143811]

### DIFF
--- a/cshared.go
+++ b/cshared.go
@@ -520,8 +520,14 @@ func decodeMsg(dec *msgpack.Decoder, tag string) (Message, error) {
 		return out, fmt.Errorf("msgpack unmarshal event time: %w", err)
 	}
 
+	// Create a decoder that preserves number types (int64 vs float64)
+	// instead of converting all numbers to float64 like the default msgpack.Unmarshal
+	recordDecoder := msgpack.NewDecoder(bytes.NewReader(entry[1]))
+	// Configure decoder to preserve exact number types instead of converting to float64
+	recordDecoder.UseLooseInterfaceDecoding(false)
+
 	var record map[string]any
-	if err := msgpack.Unmarshal(entry[1], &record); err != nil {
+	if err := recordDecoder.Decode(&record); err != nil {
 		return out, fmt.Errorf("msgpack unmarshal event record: %w", err)
 	}
 

--- a/cshared_test.go
+++ b/cshared_test.go
@@ -647,3 +647,82 @@ func TestToSnakeCase(t *testing.T) {
 		})
 	}
 }
+
+// TestNumberTypePreservation tests that the decodeMsg function preserves
+// number types (int64 vs float64) instead of converting all numbers to float64.
+func TestNumberTypePreservation(t *testing.T) {
+	now := time.Now()
+
+	// Create a message with various number types that should be preserved
+	originalRecord := map[string]any{
+		"integer_positive": int64(42),
+		"integer_negative": int64(-123),
+		"integer_zero":     int64(0),
+		"integer_large":    int64(9223372036854775807), // max int64
+		"float_simple":     float64(3.14),
+		"float_negative":   float64(-2.71),
+		"float_zero":       float64(0.0),
+		"float_scientific": float64(1.23e-4),
+		"string_value":     "test",
+		"boolean_value":    true,
+		"mixed_in_array":   []any{int64(1), float64(2.5), int64(3)},
+		"nested_map": map[string]any{
+			"nested_int":   int64(456),
+			"nested_float": float64(7.89),
+		},
+	}
+
+	msg := Message{
+		Time:   now,
+		Record: originalRecord,
+	}
+
+	// Marshal the message as it would be done by the input plugin
+	marshaledData, err := msgpack.Marshal([]any{
+		&EventTime{msg.Time},
+		msg.Record,
+	})
+	assert.NoError(t, err)
+
+	// Create a decoder and decode the message using our fixed decodeMsg function
+	decoder := msgpack.NewDecoder(bytes.NewReader(marshaledData))
+	decodedMsg, err := decodeMsg(decoder, "test-tag")
+	assert.NoError(t, err)
+
+	// Verify the decoded message structure
+	if decodedMsg.Record == nil {
+		t.Fatal("Record should not be nil")
+	}
+	record, ok := decodedMsg.Record.(map[string]any)
+	assert.True(t, ok, "Record should be a map[string]any")
+
+	// Test integer preservation
+	assert.Equal(t, int64(42), assertType[int64](t, record["integer_positive"]))
+	assert.Equal(t, int64(-123), assertType[int64](t, record["integer_negative"]))
+	assert.Equal(t, int64(0), assertType[int64](t, record["integer_zero"]))
+	assert.Equal(t, int64(9223372036854775807), assertType[int64](t, record["integer_large"]))
+
+	// Test float preservation
+	assert.Equal(t, float64(3.14), assertType[float64](t, record["float_simple"]))
+	assert.Equal(t, float64(-2.71), assertType[float64](t, record["float_negative"]))
+	assert.Equal(t, float64(0.0), assertType[float64](t, record["float_zero"]))
+	assert.Equal(t, float64(1.23e-4), assertType[float64](t, record["float_scientific"]))
+
+	// Test other types are preserved
+	assert.Equal(t, "test", assertType[string](t, record["string_value"]))
+	assert.Equal(t, true, assertType[bool](t, record["boolean_value"]))
+
+	// Test array with mixed number types
+	mixedArray := assertType[[]any](t, record["mixed_in_array"])
+	assert.Equal(t, int64(1), assertType[int64](t, mixedArray[0]))
+	assert.Equal(t, float64(2.5), assertType[float64](t, mixedArray[1]))
+	assert.Equal(t, int64(3), assertType[int64](t, mixedArray[2]))
+
+	// Test nested map with number types
+	nestedMap := assertType[map[string]any](t, record["nested_map"])
+	assert.Equal(t, int64(456), assertType[int64](t, nestedMap["nested_int"]))
+	assert.Equal(t, float64(7.89), assertType[float64](t, nestedMap["nested_float"]))
+
+	// Verify that tag is preserved
+	assert.Equal(t, "test-tag", decodedMsg.Tag())
+}


### PR DESCRIPTION
Preserves the types of fields in records by using a custom decoder with `UseLooseInterfaceDecoding(false)` set.